### PR TITLE
tweak order of ops in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM python:3.8-alpine
 
-RUN apk add --no-cache --virtual .build-deps gcc postgresql-dev musl-dev python3-dev
-RUN apk add libpq
+RUN apk add --no-cache --virtual .build-deps gcc postgresql-dev musl-dev python3-dev \
+    && pip install --no-cache-dir mypy psycopg2-binary \
+    && apk add libpq \
+    && apk del --no-cache .build-deps
 
 COPY requirements.txt /tmp/
-RUN pip install -r /tmp/requirements.txt
-
-RUN apk del --no-cache .build-deps
+RUN pip install --no-cache-dir -r /tmp/requirements.txt 
 
 RUN mkdir -p /src
 COPY src/ /src/


### PR DESCRIPTION
FWIW, this shrinks the image size by ~50% (396 MB -> 159 MB) by removing some layers.

I think it's debatable whether `mypy` and `psycog2-binary` should be provided by the deployment environment, or or are an application dependency, so it may not be to everyone's liking.