### PR TITLE
flask redirect in POST /allocate, test assert on 200, not 202

### DIFF
--- a/src/allocation/entrypoints/flask_app.py
+++ b/src/allocation/entrypoints/flask_app.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from flask import Flask, jsonify, request
+from flask import Flask, jsonify, request, redirect
 
 from allocation.domain import commands
 from allocation.adapters import notifications, orm, redis_eventpublisher
@@ -34,14 +34,15 @@ def add_batch():
 @app.route("/allocate", methods=['POST'])
 def allocate_endpoint():
     try:
+        orderid = request.json['orderid']
         cmd = commands.Allocate(
-            request.json['orderid'], request.json['sku'], request.json['qty'],
+            orderid, request.json['sku'], request.json['qty'],
         )
         bus.handle(cmd)
+        return redirect(f'/allocations/{orderid}', code=302)
     except InvalidSku as e:
         return jsonify({'message': str(e)}), 400
 
-    return 'OK', 202
 
 
 @app.route("/allocations/<orderid>", methods=['GET'])

--- a/tests/e2e/api_client.py
+++ b/tests/e2e/api_client.py
@@ -16,8 +16,9 @@ def post_to_allocate(orderid, sku, qty, expect_success=True):
     r = requests.post(f'{url}/allocate', json={
         'orderid': orderid, 'sku': sku, 'qty': qty,
     })
+    # NOTE: print(r.history) will show the intermediate re-direct
     if expect_success:
-        assert r.status_code == 202
+        assert r.status_code == 200
     return r
 
 def get_allocation(orderid):

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -13,9 +13,6 @@ def test_happy_path_returns_202_and_batch_is_allocated():
     api_client.post_to_add_batch(batch3, othersku, 100, None)
 
     r = api_client.post_to_allocate(orderid, sku, qty=3)
-    assert r.status_code == 202
-
-    r = api_client.get_allocation(orderid)
     assert r.ok
     assert r.json() == [
         {'sku': sku, 'batchref': batch2},


### PR DESCRIPTION
Adds re-direct with 302 code to `POST allocate` route to match text PRG pattern in Chapter 11 CQRS.