### PR TITLE
Corrected commands of the individual tests make commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ pip install -e src/
 ```sh
 make test
 # or, to run individual test types
-make unit
-make integration
-make e2e
+make unit-tests
+make integration-tests
+make e2e-tests
 # or, if you have a local virtualenv
 make up
 pytest tests/unit


### PR DESCRIPTION
I found the commands provided didn't work, but adding "-tests" to each command enabled running the given tests individually.

NOTE: My experience was using Linux, and utilizing the commands found in the `Building the containers` section, followed by the `Running the tests` section.