### PR TITLE
Fix: Pass OrderLine model to services functions

### DIFF
--- a/model.py
+++ b/model.py
@@ -16,7 +16,6 @@ def allocate(line: OrderLine, batches: List[Batch]) -> str:
     except StopIteration:
         raise OutOfStock(f"Out of stock for sku {line.sku}")
 
-
 @dataclass(unsafe_hash=True)
 class OrderLine:
     orderid: str

--- a/services.py
+++ b/services.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import model
-from model import OrderLine
+from model import Batch, OrderLine
 from repository import AbstractRepository
 
 
@@ -9,7 +9,7 @@ class InvalidSku(Exception):
     pass
 
 
-def is_valid_sku(sku, batches):
+def is_valid_sku(sku, batches) -> bool:
     return sku in {b.sku for b in batches}
 
 
@@ -20,3 +20,16 @@ def allocate(line: OrderLine, repo: AbstractRepository, session) -> str:
     batchref = model.allocate(line, batches)
     session.commit()
     return batchref
+
+def add_batch(batch: Batch, repo: AbstractRepository, session) -> None:
+    repo.add(batch)
+    session.commit()
+
+def deallocate(line: OrderLine, repo: AbstractRepository, session):
+    batches = repo.list()
+    for b in batches:
+        if line in b._allocations:
+            b.deallocate(line)
+            break
+    else:
+        raise ValueError("Cannot deallocate")   

--- a/test_api.py
+++ b/test_api.py
@@ -58,13 +58,17 @@ def test_unhappy_path_returns_400_and_error_message():
 def test_deallocate():
     sku, order1, order2 = random_sku(), random_orderid(), random_orderid()
     batch = random_batchref()
-    post_to_add_batch(batch, sku, 100, "2011-01-02")
     url = config.get_api_url()
+    r= requests.post(
+        f"{url}/add_batch",
+        json={"ref": batch, "sku": sku, "qty": 100, "eta": "2011-01-02"},
+    )
+    assert r.ok
     # fully allocate
     r = requests.post(
         f"{url}/allocate", json={"orderid": order1, "sku": sku, "qty": 100}
     )
-    assert r.json()["batchid"] == batch
+    assert r.json()["batchref"] == batch
 
     # cannot allocate second order
     r = requests.post(
@@ -73,12 +77,9 @@ def test_deallocate():
     assert r.status_code == 400
 
     # deallocate
+    # Just getting a connection aborted error
     r = requests.post(
-        f"{url}/deallocate",
-        json={
-            "orderid": order1,
-            "sku": sku,
-        },
+        f"{url}/deallocate", json={"orderid": order1, "sku": sku, "qty": 100},
     )
     assert r.ok
 

--- a/test_services.py
+++ b/test_services.py
@@ -55,8 +55,10 @@ def test_commits():
 
 def test_deallocate_decrements_available_quantity():
     repo, session = FakeRepository([]), FakeSession()
-    services.add_batch("b1", "BLUE-PLINTH", 100, None, repo, session)
-    services.allocate("o1", "BLUE-PLINTH", 10, repo, session)
+    line = model.OrderLine("o1", "BLUE-PLINTH", 10)
+    batch = model.Batch("b1", "BLUE-PLINTH", 100, eta=None)
+    services.add_batch(batch, repo, session)
+    services.allocate(line, repo, session)
     batch = repo.get(reference="b1")
     assert batch.available_quantity == 90
     # services.deallocate(...

--- a/test_services.py
+++ b/test_services.py
@@ -61,14 +61,20 @@ def test_deallocate_decrements_available_quantity():
     services.allocate(line, repo, session)
     batch = repo.get(reference="b1")
     assert batch.available_quantity == 90
-    # services.deallocate(...
-    ...
+    services.deallocate(line, repo, session)
     assert batch.available_quantity == 100
 
 
 def test_deallocate_decrements_correct_quantity():
     ...  #  TODO
+    # Just a check for purchased quantity?
 
 
 def test_trying_to_deallocate_unallocated_batch():
-    ...  #  TODO: should this error or pass silently? up to you.
+    repo, session = FakeRepository([]), FakeSession()
+    line = model.OrderLine("o1", "BLUE-PLINTH", 10)
+    batch = model.Batch("b1", "BLUE-PLINTH", 100, eta=None)
+    services.add_batch(batch, repo, session)
+    batch = repo.get(reference="b1")
+    with pytest.raises(ValueError, match='Cannot deallocate'):
+        services.deallocate(line, repo, session)


### PR DESCRIPTION
In the chapter and exercise, `services.allocate` takes an `OrderLine` object argument, not a series of strings/integer arguments. See [L52](https://github.com/cosmicpython/code/pull/46/files#diff-2180c4cf655cb5703c70e47ce58fa813cf8e46978ef2709f10bc2e863d49c807R52) of `test_services.py`. I assume `services.add_batch` also means to take in a Batch object argument rather than strings/integers.