### PR TITLE
fix docker compose up -d errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # app
 psycopg2-binary
-django
+django==3.2.7
 dj-database-url
 
 # tests

--- a/src/djangoproject/alloc/apps.py
+++ b/src/djangoproject/alloc/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class AllocConfig(AppConfig):
-    name = "alloc"
+    name = "djangoproject.alloc"


### PR DESCRIPTION
django app fails to boot for two reasons

Issue 1:
-------
ModuleNotFoundError: No module named 'alloc'
Fix:
app name needs to be the path
https://stackoverflow.com/a/67057826/5506988

Same as issue #38 but issue 2 started when trying to fix
issue #38

Issue 2:
-------
psycopg2.errors.UndefinedColumn: column c.relispartition does not exist
django version is not fixed and in django 4 something broke
https://stackoverflow.com/questions/69477858/django-error-column-does-not-exist-but-i-have-no-control-over-that-table#comment122830337_69477858

Fix:
Hardcode django version in requirements.txt