### PR TITLE
Update requirements.txt for SqlAlchemy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # app
-sqlalchemy
+sqlalchemy~=1.4.46 
 flask
 psycopg2-binary
 redis


### PR DESCRIPTION
Related to [Issue 41](https://github.com/cosmicpython/code/issues/41)
With the release of SqlAlchemy2 the sqlalchemy.orm.mapper() was removed completely. This causes the cosmicpython-redis_pubsub-1 and cosmicpython-api-1 containers to fail.

```
Traceback (most recent call last):
  File "/src/allocation/entrypoints/redis_eventconsumer.py", line 31, in <module>
    main()
  File "/src/allocation/entrypoints/redis_eventconsumer.py", line 15, in main
    bus = bootstrap.bootstrap()
  File "/src/allocation/bootstrap.py", line 22, in bootstrap
    orm.start_mappers()
  File "/src/allocation/adapters/orm.py", line 65, in start_mappers
    lines_mapper = mapper(model.OrderLine, order_lines)
  File "/usr/local/lib/python3.9/site-packages/sqlalchemy/orm/_orm_constructors.py", line 1880, in _mapper_fn
    raise InvalidRequestError(
sqlalchemy.exc.InvalidRequestError: The 'sqlalchemy.orm.mapper()' function is removed as of SQLAlchemy 2.0.  

Use the 'sqlalchemy.orm.registry.map_imperatively()` method of the ``sqlalchemy.orm.registry`` class to perform classical mapping.

```
Not sure what the status of [PR 44](https://github.com/cosmicpython/code/pull/44) is but as a quick fix simply specifying an explicit SqlAlchemy version in the requirements.txt allows the containers to build successfully without requiring any code changes.
```

sqlalchemy -> sqlalchemy~=1.4.46 
```