### PR TITLE
Update test_orm.py

### DIFF
--- a/test_orm.py
+++ b/test_orm.py
@@ -60,7 +60,7 @@ def test_saving_allocations(session):
     session.add(batch)
     session.commit()
     rows = list(session.execute('SELECT orderline_id, batch_id FROM "allocations"'))
-    assert rows == [(batch.id, line.id)]
+    assert rows == [(line.id, batch.id)]
 
 
 def test_retrieving_allocations(session):


### PR DESCRIPTION
minor issue.

The test passed because only one order and batch were made, but the order of the two IDs was changed.