### PR TITLE
Fix typo in test_api.py

### DIFF
--- a/test_api.py
+++ b/test_api.py
@@ -64,7 +64,7 @@ def test_deallocate():
     r = requests.post(
         f"{url}/allocate", json={"orderid": order1, "sku": sku, "qty": 100}
     )
-    assert r.json()["batchid"] == batch
+    assert r.json()["batchref"] == batch
 
     # cannot allocate second order
     r = requests.post(
@@ -87,4 +87,4 @@ def test_deallocate():
         f"{url}/allocate", json={"orderid": order2, "sku": sku, "qty": 100}
     )
     assert r.ok
-    assert r.json()["batchid"] == batch
+    assert r.json()["batchref"] == batch


### PR DESCRIPTION
**Context**
Tests for the deallocate end point have a typo in the payload.

**Proposed solution**
Fix typo: `r.json()["batchrid"]` -> `r.json()["batchref"]`